### PR TITLE
Fixing issue 39 (quickopend unresponsive on linux workstation).

### DIFF
--- a/src/find_based_db_indexer.py
+++ b/src/find_based_db_indexer.py
@@ -110,7 +110,7 @@ def _get_filename_relative_to_find_dir(current_find_dir, filename):
 def _IsProcessRunnable(name):
   try:
     with open(os.devnull, 'w') as devnull:
-      found = subprocess.call(['which', name],
+      found = subprocess.call(['/usr/bin/which', name],
                               stdout=devnull, stderr=devnull) == 0
       return True
   except OSError:


### PR DESCRIPTION
The issue was that to check if '/usr/bin/find' was runnable, it was being run from /, which could take hours to complete. The entire quickopend was blocked on waiting for find to search the entire system.
