### PR TITLE
Change help message for 'ignore' to describe the patterns as using fnmatch syntax.

### DIFF
--- a/src/quickopen.py
+++ b/src/quickopen.py
@@ -92,7 +92,7 @@ def CMDrmdir(parser):
   return 255
 
 def CMDignore(parser):
-  """Ignores files matching the given regexp"""
+  """Ignores files matching the given fnmatch glob pattern"""
   (options, args) = parser.parse_args()
   db = open_db(options)
   if len(args) == 0:


### PR DESCRIPTION
I initially tried to enter regular expressions to ignore filenames, but apparently fnmatch's glob-style syntax is required (e.g. "*.o" instead of "\.o$"), which confused me for a good few minutes.