### PR TITLE
Explicitly find and use python2.

### DIFF
--- a/quickopen
+++ b/quickopen
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # Copyright 2011 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/quickopend
+++ b/quickopend
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright 2011 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Quickopen currently requires python2, but modern systems no longer
provide python2 as python. Adding this explicitly fixes invoking
quickopen on modern debian releases when python2 is installed.